### PR TITLE
fix for debian stretch

### DIFF
--- a/pathing_check/exp1_dependent_jar_in_same_dir/run.sh
+++ b/pathing_check/exp1_dependent_jar_in_same_dir/run.sh
@@ -7,4 +7,4 @@ unzip -p pathing.jar META-INF/MANIFEST.MF
 
 java -version
 
-java -cp pathing.jar:. Test
+java -Djdk.net.URLClassPath.disableClassPathURLCheck=true -cp pathing.jar:. Test

--- a/pathing_check/exp2_dependent_jar_in_parent_dir/run.sh
+++ b/pathing_check/exp2_dependent_jar_in_parent_dir/run.sh
@@ -8,4 +8,4 @@ unzip -p pathing.jar META-INF/MANIFEST.MF
 
 java -version
 
-java -cp pathing.jar:. Test
+java -Djdk.net.URLClassPath.disableClassPathURLCheck=true -cp pathing.jar:. Test

--- a/pathing_check/exp3_dependent_jar_in_absolute_path/run.sh
+++ b/pathing_check/exp3_dependent_jar_in_absolute_path/run.sh
@@ -8,4 +8,4 @@ unzip -p pathing.jar META-INF/MANIFEST.MF
 
 java -version
 
-java -cp pathing.jar:. Test
+java -Djdk.net.URLClassPath.disableClassPathURLCheck=true -cp pathing.jar:. Test


### PR DESCRIPTION
So there was a patch update in debian which broke a few things, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925#38 in essence they make a new default
```
jdk.net.URLClassPath.disableClassPathURLCheck=false
```
which manifests itself in a variety of pretty bugs like this.

I'll be making the same PR for gocd in a sec.

Thanks a lot, that really helped.